### PR TITLE
Pipeline Input for Import-Psd

### DIFF
--- a/PsdKit.psm1
+++ b/PsdKit.psm1
@@ -158,31 +158,33 @@ function Get-Psd {
 function Import-Psd {
 	[OutputType([Hashtable])]
 	param(
-		[Parameter(Position=0, Mandatory=1)]
+		[Parameter(Position=0, Mandatory=1, ValueFromPipeline=1)]
 		[string] $Path,
 		[hashtable] $MergeInto,
 		[switch] $Unsafe
 	)
-	trap {ThrowTerminatingError $_}
+	process {
+		trap {ThrowTerminatingError $_}
 
-	$Path = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($Path)
-	if ($Unsafe) {
-		$block = [scriptblock]::Create([System.IO.File]::ReadAllText($Path))
-		$data = & $block
-	}
-	else {
-		$data = $null
-		Import-LocalizedData -BaseDirectory ([System.IO.Path]::GetDirectoryName($Path)) -FileName ([System.IO.Path]::GetFileName($Path)) -BindingVariable data
-	}
-
-	if ($MergeInto) {
-		if ($data -isnot [hashtable]) {throw 'With Merge imported data must be a hastable.'}
-		foreach($_ in $data.GetEnumerator()) {
-			$MergeInto[$_.Key] = $_.Value
+		$Path = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($Path)
+		if ($Unsafe) {
+			$block = [scriptblock]::Create([System.IO.File]::ReadAllText($Path))
+			$data = & $block
 		}
-	}
-	else {
-		$data
+		else {
+			$data = $null
+			Import-LocalizedData -BaseDirectory ([System.IO.Path]::GetDirectoryName($Path)) -FileName ([System.IO.Path]::GetFileName($Path)) -BindingVariable data
+		}
+
+		if ($MergeInto) {
+			if ($data -isnot [hashtable]) {throw 'With Merge imported data must be a hastable.'}
+			foreach($_ in $data.GetEnumerator()) {
+				$MergeInto[$_.Key] = $_.Value
+			}
+		}
+		else {
+			$data
+		}
 	}
 }
 


### PR DESCRIPTION
Hello,

just a tiny improvement: Next to `Import-Psd $Path`, it supports now `$Path | Import-Psd` .
Unfortunately I wasn't able to execute the tests successfully (even without my change). It fails with `Test-Hash $r 9b008c8dd6952bfa5bd30f09d7944155` .

Best regards
